### PR TITLE
Update mainnet readme with quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,108 @@
 # Cosmos Hub Mainnet
 
-The current Gaia Version of the Cosmos Hub mainnet is [v5.0.2](https://github.com/cosmos/gaia/releases/tag/v5.0.2). However if you want to build a node from scratch you need to first run [v4.2.6](https://github.com/cosmos/gaia/releases/tag/v4.2.6) until the node panics at block height [6910000](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021). The node should stop running after the panic, if it does not stop automatically, wait for 5-10 minutes and then kill it manually. Now install the latest version of gaia ([v5.0.2](https://github.com/cosmos/gaia/releases/tag/v5.0.2)) and then begin running the binary agian with the optional flag `--x-crisis-skip-assert-invariants`. This will begin syncing the node since the last upgrade until it is at the current height.
+## Overview
 
-You can skip this process if you have access to a snapshot of the blockchain after height 6910000. You can find snapshots at [cosmos.quicksync.io](https://cosmos.quicksync.io/).
+The current Gaia Version of the Cosmos Hub mainnet is [`v6.0.0`](https://github.com/cosmos/gaia/releases/tag/v6.0.0). To bootstrap a mainnet node, it is possible to sync from `V6.0.0` via Quicksync or via [State Sync](https://hub.cosmos.network/main/hub-tutorials/join-mainnet.html#state-sync).
 
-# Join the Cosmos Hub Mainnet
+However if you want to build a node from scratch you need to first run [v4.2.6](https://github.com/cosmos/gaia/releases/tag/v4.2.6) until the node panics at block height [6910000](https://github.com/cosmos/gaia/blob/main/docs/migration/cosmoshub-4-delta-upgrade.md#Upgrade-will-take-place-July-12,-2021). The node should stop running after the panic, if it does not stop automatically, wait for 5-10 minutes and then kill it manually. Now install the latest version of gaia ([v5.0.2](https://github.com/cosmos/gaia/releases/tag/v5.0.2)) and then begin running the binary agian with the optional flag `--x-crisis-skip-assert-invariants`. This will begin syncing the node since the last upgrade until it is at the current height.
 
 ## Quickstart
 
-**Instant Gratification Snippet**
+**Preresquisites**
+- `make` & `gcc`
+- `Go 1.16+`
+
+> **Note**: Make sure to have all prerequisites installed. See the [installation docs](https://hub.cosmos.network/main/getting-started/installation.html) for clarification and a detailed set of instructions.
+
+**Quicksync**
+
+Quicksync.io offers several daily snapshots of the Cosmos Hub with varying levels of pruning (archive 1.4TB, default 540GB, and pruned 265GB). For downloads and installation instructions, visit the [Cosmos Quicksync guide](https://quicksync.io/networks/cosmos.html).
+
+**State Sync**
+
+To enable state sync, visit an [explorer](https://www.mintscan.io/cosmos/blocks) to get a recent block height and corresponding hash. A node operator can choose any height/hash in the current bonding period, but as the recommended snapshot period is 1000 blocks, it is advised to choose something close to current height - 1000. Set these parameters in the code snippet below `<BLOCK_HEIGHT>` and `<BLOCK_HASH>`
+
+For reference, the list of `rpc_servers` and `persistent` peers can be found in the [cosmos hub chain-registry repo](https://github.com/cosmos/chain-registry/blob/master/cosmoshub/chain.json).
 
 ```bash
-git clone -b v4.2.0 https://github.com/cosmos/gaia
+# Build gaiad binary and initialize chain
+cd $HOME
+git clone -b v6.0.0 https://github.com/cosmos/gaia
+cd gaiad
+make install
+gaiad init <custom moniker>
+
+# Prepare genesis file for cosmoshub-4
+wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
+gzip -d genesis.cosmoshub-4.json.gz
+mv genesis.cosmoshub-4.json $HOME/.gaia/config/genesis.json
+
+#Set minimum gas price & peers
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.001uatom"/' app.toml
+sed -i 's/persistent_peers = ""/persistent_peers = "6e08b23315a9f0e1b23c7ed847934f7d6f848c8b@165.232.156.86:26656,ee27245d88c632a556cf72cc7f3587380c09b469@45.79.249.253:26656,538ebe0086f0f5e9ca922dae0462cc87e22f0a50@34.122.34.67:26656,d3209b9f88eec64f10555a11ecbf797bb0fa29f4@34.125.169.233:26656,bdc2c3d410ca7731411b7e46a252012323fbbf37@34.83.209.166:26656,585794737e6b318957088e645e17c0669f3b11fc@54.160.123.34:26656,5b4ed476e01c49b23851258d867cc0cfc0c10e58@206.189.4.227:26656"/' config.toml
+
+# Configure State sync
+cd $HOME/.gaia/config
+sed -i 's/enable = false/enable = true/' config.toml
+sed -i 's/trust_height = 0/trust_height = <BLOCK_HEIGHT>/' config.toml
+sed -i 's/trust_hash = ""/trust_hash = "<BLOCK_HASH>"/' config.toml
+sed -i 's/rpc_servers = ""/rpc_servers = "https:\/\/rpc.cosmos.network:443,https:\/\/rpc.cosmos.network:443"/' config.toml
+
+#Start Gaia
+gaiad start --x-crisis-skip-assert-invariants
+```
+
+**Sync from Scratch**
+
+```bash
+# Build gaiad binary and initialize chain
+git clone -b v4.2.1 https://github.com/cosmos/gaia
 cd gaia
 make install
-gaiad init chooseanicehandle
+gaiad init <custom moniker>
+
+# Prepare genesis file for cosmoshub-4
 wget https://github.com/cosmos/mainnet/raw/master/genesis.cosmoshub-4.json.gz
 gzip -d genesis.cosmoshub-4.json.gz
 mv genesis.cosmoshub-4.json ~/.gaia/config/genesis.json
-gaiad start --p2p.seeds bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656 --x-crisis-skip-assert-invariants
+
+
+#Set minimum gas price & peers
+sed -i 's/minimum-gas-prices = ""/minimum-gas-prices = "0.001uatom"/' app.toml
+sed -i 's/persistent_peers = ""/persistent_peers = "6e08b23315a9f0e1b23c7ed847934f7d6f848c8b@165.232.156.86:26656,ee27245d88c632a556cf72cc7f3587380c09b469@45.79.249.253:26656,538ebe0086f0f5e9ca922dae0462cc87e22f0a50@34.122.34.67:26656,d3209b9f88eec64f10555a11ecbf797bb0fa29f4@34.125.169.233:26656,bdc2c3d410ca7731411b7e46a252012323fbbf37@34.83.209.166:26656,585794737e6b318957088e645e17c0669f3b11fc@54.160.123.34:26656,5b4ed476e01c49b23851258d867cc0cfc0c10e58@206.189.4.227:26656"/' config.toml
+
+gaiad start --x-crisis-skip-assert-invariants
 ```
-Now wait until the chain reaches block height XXXX. It will panic and you will see a message like:
+Now wait until the chain reaches block height 6910000. It will panic and log the following:
 ```
 ERR UPGRADE "Gravity-DEX" NEEDED at height: 6910000: v5.0.0-4760cf1f1266accec7a107f440d46d9724c6fd08
 
 panic: UPGRADE "Gravity-DEX" NEEDED at height: 6910000: v5.0.0-4760cf1f1266accec7a107f440d46d9724c6fd08
 ```
-Then you should run the following commands:
+
+It's now time to perform the manual Delta upgrade:
 ```bash
 git checkout -b v5.0.2
 make install
-gaiad start --x-crisis-skip-assert-invariants --p2p.seeds bf8328b66dceb4987e5cd94430af66045e59899f@public-seed.cosmos.vitwit.com:26656,cfd785a4224c7940e9a10f6c1ab24c343e923bec@164.68.107.188:26656,d72b3011ed46d783e369fdf8ae2055b99a1e5074@173.249.50.25:26656,ba3bacc714817218562f743178228f23678b2873@public-seed-node.cosmoshub.certus.one:26656,3c7cad4154967a294b3ba1cc752e40e8779640ad@84.201.128.115:26656
+gaiad start --x-crisis-skip-assert-invariants
 ```
 
-Note:  If your node is unable to connect to any of the seeds listed here, you can find seeds and peers in [this document](https://hackmd.io/@KFEZk8oMTz6vBlwADz0M4A/BkKEUOsZu#) maintained by community members, and at [Atlas](https://atlas.cosmos.network/nodes), which is automatically generated by crawling the network.
+Once `V5` reaches the upgrade block height, the chain will halt and display the following message:
+```
+ERR UPGRADE "Vega" NEEDED at height: 8695000
 
-If you'd like to save those seeds to your settings put them in ~/.gaia/config/config.toml in the p2p section under seeds in the same comma-separated list format.
+```
 
-**You need to [install gaia](./installation.md) before you go further**
+This will indicate it is time to perform the Vega upgrade. Similar with the previous upgrade, checkout `V6`, compile the new binary and restart `gaiad`
 
-**Gaia nodes on cosmoshub-4 take longer than 45 min to startup. The development team are evaluating [solutions](https://github.com/cosmos/cosmos-sdk/issues/7766).**
+```bash
+git checkout -b v6.0.0
+make install
+gaiad start --x-crisis-skip-assert-invariants
+```
+
+> _NOTE_:  If the node is unable to connect to any of the seeds listed here, find additional seeds and peers in [this document](https://hackmd.io/@KFEZk8oMTz6vBlwADz0M4A/BkKEUOsZu#) maintained by community members, and at [Atlas](https://atlas.cosmos.network/nodes), which is automatically generated by crawling the network. Additionally, node operators can just copy [Quicksync's addressbook](https://quicksync.io/addrbook.cosmos.json) and move it to `$HOME/.gaia/config/addrbook.json`
+
 
 ## Setting Up a New Node
 
@@ -143,25 +206,9 @@ By default every node is in `PruneSyncable` mode. If you would like to change yo
 
 > Note: When you are pruning state you will not be able to query the heights that are not in your store.
 
-## Run a Full Node
+## Exporting State
 
-Start the full node with this command:
-
-```bash
-gaiad start
-```
-
-Check that everything is running smoothly:
-
-```bash
-gaiad status
-```
-
-View the status of the network with the [Cosmos Explorer](https://cosmos.network/launch).
-
-## Export State
-
-Gaia can dump the entire application state to a JSON file, which could be useful for manual analysis and can also be used as the genesis file of a new network.
+Gaia can dump the entire application state into a JSON file. This application state dump is useful for manual analysis and can also be used as the genesis file of a new network.
 
 Export state with:
 
@@ -169,34 +216,29 @@ Export state with:
 gaiad export > [filename].json
 ```
 
-You can also export state from a particular height (at the end of processing the block of that height):
+It is also possible to export state from a particular height (at the end of processing the block of that height):
 
 ```bash
 gaiad export --height [height] > [filename].json
 ```
 
-If you plan to start a new network from the exported state, export with the `--for-zero-height` flag:
+If planning to start a new network from the exported state, export with the `--for-zero-height` flag:
 
 ```bash
 gaiad export --height [height] --for-zero-height > [filename].json
 ```
 
+
 ## Verify Mainnet
 
 Help to prevent a catastrophe by running invariants on each block on your full
-node. In essence, by running invariants you ensure that the state of mainnet is
-the correct expected state. One vital invariant check is that no atoms are
-being created or destroyed outside of expected protocol, however there are many
-other invariant checks each unique to their respective module. Because invariant checks
-are computationally expensive, they are not enabled by default. To run a node with
-these checks start your node with the assert-invariants-blockly flag:
+node. In essence, by running invariants the node operator ensures that the state of mainnet is the correct expected state. One vital invariant check is that no atoms are being created or destroyed outside of expected protocol, however there are many other invariant checks each unique to their respective module. Because invariant checks are computationally expensive, they are not enabled by default. To run a node with these checks start your node with the assert-invariants-blockly flag:
 
 ```bash
 gaiad start --assert-invariants-blockly
 ```
 
-If an invariant is broken on your node, your node will panic and prompt you to send
-a transaction which will halt mainnet. For example the provided message may look like:
+If an invariant is broken on the node, it will panic and prompt the operator to send a transaction which will halt mainnet. For example the provided message may look like:
 
 ```bash
 invariant broken:
@@ -207,9 +249,6 @@ invariant broken:
         gaiad tx crisis invariant-broken staking supply
 
 ```
-
-When submitting a invariant-broken transaction, transaction fee tokens are not
-deducted as the blockchain will halt (aka. this is a free transaction).
 
 ## Upgrade to Validator Node
 


### PR DESCRIPTION
The current readme for joining mainnet is out of date, last updated for the Delta upgrade. The proposed changes to the readme will simply document how to quickstart a node as of the Vega upgrade, with the eventual goal of adding the quickstart section to the main documentation of the hub. Information about gas fees, pruning, exporting state and etc have been consolidated in https://github.com/cosmos/gaia/pull/1146. 